### PR TITLE
Fix Spawning Rules not accounting for all Actor classes

### DIFF
--- a/zscript/Hexadoken/SpawnHandler.zsc
+++ b/zscript/Hexadoken/SpawnHandler.zsc
@@ -231,7 +231,7 @@ class HexaDokenHandler : EventHandler {
 
         // M1 Garand
         Array<HexaSpawnItemEntry> spawns_Garand;
-        spawns_Garand.push(addItemEntry('LiberatorRifle', gar_shellbox_spawn_bias));
+        spawns_Garand.push(addItemEntry('LiberatorRandom', gar_shellbox_spawn_bias));
         addItem('HDGarandRandom', spawns_Garand, gar_persistent_spawning);
 
         // .50 OMG Boss Rifle
@@ -265,12 +265,12 @@ class HexaDokenHandler : EventHandler {
     }
 
     // Tries to create the item via random spawning.
-    bool tryCreateItem(Inventory item, HexaSpawnItem f, int g, bool rep) {
+    bool tryCreateItem(Actor thing, HexaSpawnItem f, int g, bool rep) {
         if (giveRandom(f.spawnReplaces[g].chance)) {
-            if (Actor.Spawn(f.spawnName, item.pos) && rep) {
-                if (hd_debug) console.printf(item.GetClassName().." -> "..f.spawnName);
+            if (Actor.Spawn(f.spawnName, thing.pos) && rep) {
+                if (hd_debug) console.printf(thing.GetClassName().." -> "..f.spawnName);
 
-                item.destroy();
+                thing.destroy();
 
                 return true;
             }
@@ -294,15 +294,14 @@ class HexaDokenHandler : EventHandler {
         
         // Pointers for specific classes.
         let ammo = HDAmmo(e.Thing);
-        let item = Inventory(e.Thing);
         
-		// If the thing spawned is an ammunition, add any and all items that can use this.
+        // If the thing spawned is an ammunition, add any and all items that can use this.
         if (ammo) handleAmmoUses(ammo, candidateName);
 
-		// Return if range before replacing things.
+        // Return if range before replacing things.
         if (level.MapName ~== "RANGE") return;
 
-        if (item) handleWeaponReplacements(item, ammo, candidateName);
+        handleWeaponReplacements(e.Thing, ammo, candidateName);
     }
 
     private void handleAmmoUses(HDAmmo ammo, string candidateName) {
@@ -312,13 +311,13 @@ class HexaDokenHandler : EventHandler {
                 // Appends each entry in that ammo's subarray.
                 for (let j = 0; j < ammoSpawnList[i].weaponNames.size(); j++) {
                     // Actual pushing to itemsthatusethis().
-                    if (ammo) ammo.ItemsThatUseThis.Push(ammoSpawnList[i].weaponNames[j]);
+                    ammo.ItemsThatUseThis.Push(ammoSpawnList[i].weaponNames[j]);
                 }
             }
         }
     }
 
-    private void handleWeaponReplacements(Inventory item, HDAmmo ammo, string candidateName) {
+    private void handleWeaponReplacements(Actor thing, HDAmmo ammo, string candidateName) {
         
         // Checks if the level has been loaded more than 1 tic.
         bool prespawn = !(level.maptime > 1);
@@ -328,12 +327,13 @@ class HexaDokenHandler : EventHandler {
             
             // if an item is owned or is an ammo (doesn't retain owner ptr), 
             // do not replace it. 
-            if ((prespawn || itemSpawnList[i].isPersistent) && (!item.owner && (!ammo || prespawn))) {
+            let item = Inventory(thing);
+            if ((prespawn || itemSpawnList[i].isPersistent) && (!(item && item.owner) && (!ammo || prespawn))) {
                 for (let j = 0; j < itemSpawnList[i].spawnReplaces.size(); j++) {
                     if (itemSpawnList[i].spawnReplaces[j].name == candidateName) {
-						if (hd_debug) console.printf("Attempting to replace "..candidateName.." with "..itemSpawnList[i].spawnName.."...");
+                        if (hd_debug) console.printf("Attempting to replace "..candidateName.." with "..itemSpawnList[i].spawnName.."...");
 
-                        if (tryCreateItem(item, itemSpawnList[i], j, itemSpawnList[i].replaceItem)) return;
+                        if (tryCreateItem(thing, itemSpawnList[i], j, itemSpawnList[i].replaceItem)) return;
                     }
                 }
             }

--- a/zscript/Hexadoken/Weapons/M1 Garand.zsc
+++ b/zscript/Hexadoken/Weapons/M1 Garand.zsc
@@ -909,10 +909,11 @@ class HDGarandRandom:IdleDummy{
 			for(int i=0;i<5;i++)lll.args[i]=args[i];
 			if(random(0,4)<2)lll.weaponstatus[0]|=GARF_RELOADER;
 			if(!random(0,9))lll.weaponstatus[0]|=GARF_BUMP;
-			A_SpawnItemEx("HDGarandClip",randompick(-4,4),randompick(-4,4),0,0,0,0,0,SXF_NOCHECKPOSITION);
-			A_SpawnItemEx("HDGarandClip",randompick(-3,3),randompick(-3,3),0,0,0,0,0,SXF_NOCHECKPOSITION);
-			A_SpawnItemEx("HDGarandClip",randompick(-2,2),randompick(-2,2),0,0,0,0,0,SXF_NOCHECKPOSITION);
-			A_SpawnItemEx("HDGarandClip",randompick(-1,1),randompick(-1,1),0,0,0,0,0,SXF_NOCHECKPOSITION);
+			let clipName = GarandAmmoThinker.get().realAmmo ? "HDGarandClip" : "HDGarand3006Clip";
+			A_SpawnItemEx(clipName,randompick(-4,4),randompick(-4,4),0,0,0,0,0,SXF_NOCHECKPOSITION);
+			A_SpawnItemEx(clipName,randompick(-3,3),randompick(-3,3),0,0,0,0,0,SXF_NOCHECKPOSITION);
+			A_SpawnItemEx(clipName,randompick(-2,2),randompick(-2,2),0,0,0,0,0,SXF_NOCHECKPOSITION);
+			A_SpawnItemEx(clipName,randompick(-1,1),randompick(-1,1),0,0,0,0,0,SXF_NOCHECKPOSITION);
 		}stop;
 	}
 }


### PR DESCRIPTION
Seems my prior refactoring cut out any actor that wasn't an Inventory, which eliminates any possibility of replacements happening over IdleDummy spawns.  Passing around the raw Actor and only casting it into an Inventory when needed should solve that problem.